### PR TITLE
Persist username from login to verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 public/css
+data/uploads/*.png
+data/uploads/*.jp?g

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,11 @@
         "laminas/laminas-config-aggregator": "^1.18",
         "laminas/laminas-servicemanager": "^4.4",
         "mezzio/mezzio-fastroute": "^3.13",
+        "mezzio/mezzio-session": "^1.16",
+        "mezzio/mezzio-session-ext": "^1.20",
         "mezzio/mezzio-twigrenderer": "^2.17",
-        "twilio/sdk": "^8.6"
+        "twilio/sdk": "^8.6",
+        "vlucas/phpdotenv": "^5.6"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~3.1.0",

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "laminas/laminas-config-aggregator": "^1.18",
         "laminas/laminas-servicemanager": "^4.4",
         "mezzio/mezzio-fastroute": "^3.13",
+        "mezzio/mezzio-flash": "^1.9",
         "mezzio/mezzio-session": "^1.16",
         "mezzio/mezzio-session-ext": "^1.20",
         "mezzio/mezzio-twigrenderer": "^2.17",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "cs-fix": "phpcbf",
         "serve": [
             "Composer\\Config::disableProcessTimeout",
-            "php -S 0.0.0.0:8080 -t public/"
+            "php -d upload_max_filesize=5242880 -d post_max_size=7340032 -S 0.0.0.0:8080 -t public/"
         ],
         "static-analysis": "phpstan analyse --memory-limit=256M --level=7 src test",
         "test": "phpunit --colors=always"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28e4bb2daa8852175bcc211ca9d536de",
+    "content-hash": "f173fc8cfe54f2e09b7e84d74d334260",
     "packages": [
         {
             "name": "asgrim/mini-mezzio",
@@ -979,6 +979,76 @@
                 }
             ],
             "time": "2025-04-27T12:05:55+00:00"
+        },
+        {
+            "name": "mezzio/mezzio-flash",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-flash.git",
+                "reference": "366439125d4b015439e468a59c32f91099ecf0b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-flash/zipball/366439125d4b015439e468a59c32f91099ecf0b5",
+                "reference": "366439125d4b015439e468a59c32f91099ecf0b5",
+                "shasum": ""
+            },
+            "require": {
+                "mezzio/mezzio-session": "^1.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "conflict": {
+                "zendframework/zend-expressive-flash": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\Flash\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Flash\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Flash messages for PSR-7 and PSR-15 applications using mezzio-session",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "flash",
+                "laminas",
+                "mezzio",
+                "middleware",
+                "psr-15",
+                "psr-7",
+                "session"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio-flash/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-flash/issues",
+                "rss": "https://github.com/mezzio/mezzio-flash/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-flash"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-16T21:13:18+00:00"
         },
         {
             "name": "mezzio/mezzio-helpers",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d51ce988c45ce8da95134ff3a817f5a",
+    "content-hash": "28e4bb2daa8852175bcc211ca9d536de",
     "packages": [
         {
             "name": "asgrim/mini-mezzio",
@@ -110,6 +110,68 @@
             "time": "2024-05-10T17:15:19+00:00"
         },
         {
+            "name": "dflydev/fig-cookies",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-fig-cookies.git",
+                "reference": "ebe6c15c9895fc490efe620ad734c8ef4a85bdb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/ebe6c15c9895fc490efe620ad734c8ef4a85bdb0",
+                "reference": "ebe6c15c9895fc490efe620ad734c8ef4a85bdb0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/http-message": "^1.0.1 || ^2"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "phpunit/phpunit": "^7.2.6 || ^9",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.3",
+                "vimeo/psalm": "^4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dflydev\\FigCookies\\": "src/Dflydev/FigCookies"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com"
+                }
+            ],
+            "description": "Cookies for PSR-7 HTTP Message Interface.",
+            "keywords": [
+                "cookies",
+                "psr-7",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/dflydev/dflydev-fig-cookies/issues",
+                "source": "https://github.com/dflydev/dflydev-fig-cookies/tree/v3.1.0"
+            },
+            "time": "2023-07-18T20:41:43+00:00"
+        },
+        {
             "name": "fig/http-message-util",
             "version": "1.1.5",
             "source": {
@@ -164,6 +226,68 @@
                 "source": "https://github.com/php-fig/http-message-util/tree/1.1.5"
             },
             "time": "2020-11-24T22:02:12+00:00"
+        },
+        {
+            "name": "graham-campbell/result-type",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/3ba905c11371512af9d9bdd27d99b782216b6945",
+                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-20T21:45:45+00:00"
         },
         {
             "name": "laminas/laminas-config-aggregator",
@@ -1018,6 +1142,154 @@
             "time": "2024-10-16T21:18:01+00:00"
         },
         {
+            "name": "mezzio/mezzio-session",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-session.git",
+                "reference": "b58dc7ad0c895a109e7849c3f2f991120eb8b61d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-session/zipball/b58dc7ad0c895a109e7849c3f2f991120eb8b61d",
+                "reference": "b58dc7ad0c895a109e7849c3f2f991120eb8b61d",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/fig-cookies": "^3.0",
+                "ext-json": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "conflict": {
+                "zendframework/zend-expressive-session": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-diactoros": "^3.4.0",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "mezzio/mezzio-csrf": "^1.0 || ^1.0-dev for CSRF protection capabilities",
+                "mezzio/mezzio-flash": "^1.0 || ^1.0-dev for flash message capabilities",
+                "mezzio/mezzio-session-ext": "^1.0 || ^1.0-dev for an ext-session persistence adapter"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\Session\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Session\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Session container and middleware for PSR-7 applications",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "laminas",
+                "mezzio",
+                "middleware",
+                "psr-7",
+                "session"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio-session/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-session/issues",
+                "rss": "https://github.com/mezzio/mezzio-session/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-session"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-16T21:28:57+00:00"
+        },
+        {
+            "name": "mezzio/mezzio-session-ext",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-session-ext.git",
+                "reference": "5db6a1780fdafa328f85311ecadffd1d5f0c4a7b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-session-ext/zipball/5db6a1780fdafa328f85311ecadffd1d5f0c4a7b",
+                "reference": "5db6a1780fdafa328f85311ecadffd1d5f0c4a7b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-session": "*",
+                "mezzio/mezzio-session": "^1.4",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "amphp/amp": "<2.6.4",
+                "zendframework/zend-expressive-session-ext": "*"
+            },
+            "require-dev": {
+                "dflydev/fig-cookies": "^3.1",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-diactoros": "^3.4",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\Session\\Ext\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Session\\Ext\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "ext-session persistence adapter for mezzio-session",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "components",
+                "ext-session",
+                "laminas",
+                "mezzio",
+                "psr-7",
+                "session"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio-session-ext/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-session-ext/issues",
+                "rss": "https://github.com/mezzio/mezzio-session-ext/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-session-ext"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-16T21:26:31+00:00"
+        },
+        {
             "name": "mezzio/mezzio-template",
             "version": "2.11.0",
             "source": {
@@ -1262,6 +1534,81 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
             "time": "2024-12-30T11:07:19+00:00"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/e3fac8b24f56113f7cb96af14958c0dd16330f54",
+                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-20T21:41:07+00:00"
         },
         {
             "name": "psr/container",
@@ -1765,6 +2112,86 @@
             "time": "2024-12-23T08:48:59+00:00"
         },
         {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-02T08:10:11+00:00"
+        },
+        {
             "name": "twig/twig",
             "version": "v3.21.1",
             "source": {
@@ -1892,6 +2319,90 @@
                 "twilio"
             ],
             "time": "2025-05-13T09:51:13+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v5.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "graham-campbell/result-type": "^1.1.3",
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.3",
+                "symfony/polyfill-ctype": "^1.24",
+                "symfony/polyfill-mbstring": "^1.24",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-filter": "*",
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
+            },
+            "suggest": {
+                "ext-filter": "Required to use the boolean validator."
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "5.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://github.com/vlucas"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-30T23:37:27+00:00"
         },
         {
             "name": "webimpress/safe-writer",

--- a/public/index.php
+++ b/public/index.php
@@ -20,7 +20,9 @@ use Mezzio\Router\RouterInterface;
 use Mezzio\Session\ConfigProvider as MezzioSessionConfigProvider;
 use Mezzio\Session\Ext\ConfigProvider as MezzioSessionExtConfigProvider;
 use Mezzio\Session\SessionMiddleware;
+use Mezzio\Template\TemplateRendererInterface;
 use Mezzio\Twig\ConfigProvider as MezzioTwigConfigProvider;
+use Psr\Container\ContainerInterface;
 use Twilio\Rest\Client;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -79,6 +81,37 @@ $container->setFactory(TwilioVerificationService::class, new class {
         return new TwilioVerificationService($client, $_ENV['VERIFY_SERVICE_SID']);
     }
 });
+
+$container->setFactory(LoginHandler::class, new class {
+    public function __invoke(ContainerInterface $container): LoginHandler
+    {
+        return new LoginHandler(
+            $container->get(TemplateRendererInterface::class),
+            $container->get(TwilioVerificationService::class),
+            $container->get('config')['users'],
+        );
+    }
+});
+
+$container->setFactory(VerifyHandler::class, new class {
+    public function __invoke(ContainerInterface $container): VerifyHandler
+    {
+        return new VerifyHandler(
+            $container->get(TemplateRendererInterface::class),
+            $container->get(TwilioVerificationService::class),
+            $container->get('config')['users'],
+        );
+    }
+});
+
+$container->setFactory(UploadHandler::class, new class {
+    public function __invoke(ContainerInterface $container): UploadHandler
+    {
+        return new UploadHandler(
+            $container->get(TemplateRendererInterface::class),
+            $container->get('config')['upload'],
+        );
+    }
 });
 
 $app = AppFactory::create($container, $container->get(RouterInterface::class));

--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Handler\LoginHandler;
 use App\Handler\UploadHandler;
 use App\Handler\VerifyHandler;
+use App\Service\TwilioVerificationService;
 use Asgrim\MiniMezzio\AppFactory;
 use Dotenv\Dotenv;
 use Laminas\ConfigAggregator\ConfigAggregator;
@@ -20,6 +21,7 @@ use Mezzio\Session\ConfigProvider as MezzioSessionConfigProvider;
 use Mezzio\Session\Ext\ConfigProvider as MezzioSessionExtConfigProvider;
 use Mezzio\Session\SessionMiddleware;
 use Mezzio\Twig\ConfigProvider as MezzioTwigConfigProvider;
+use Twilio\Rest\Client;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -67,6 +69,16 @@ $container                          = new ServiceManager($dependencies);
 $container->addAbstractFactory(new ReflectionBasedAbstractFactory());
 $container->setFactory(RouterInterface::class, static function () {
     return new FastRouteRouter();
+$container->setFactory(TwilioVerificationService::class, new class {
+    public function __invoke(ContainerInterface $container): TwilioVerificationService
+    {
+        $client = new Client(
+            $_ENV['TWILIO_ACCOUNT_SID'],
+            $_ENV['TWILIO_AUTH_TOKEN'],
+        );
+        return new TwilioVerificationService($client, $_ENV['VERIFY_SERVICE_SID']);
+    }
+});
 });
 
 $app = AppFactory::create($container, $container->get(RouterInterface::class));

--- a/public/index.php
+++ b/public/index.php
@@ -57,6 +57,12 @@ $config                             = new ConfigAggregator([
 ])->getMergedConfig();
 $dependencies                       = $config['dependencies'];
 $dependencies['services']['config'] = $config;
+$dependencies['services']['config']['upload'] = [
+    'upload_dir' => __DIR__ . '/../' . $_SERVER['UPLOAD_DIRECTORY'],
+];
+$dependencies['services']['config']['users']  = [
+    $_SERVER['YOUR_USERNAME'] => $_SERVER['YOUR_PHONE_NUMBER'],
+];
 $container                          = new ServiceManager($dependencies);
 $container->addAbstractFactory(new ReflectionBasedAbstractFactory());
 $container->setFactory(RouterInterface::class, static function () {

--- a/public/index.php
+++ b/public/index.php
@@ -6,6 +6,7 @@ use App\Handler\LoginHandler;
 use App\Handler\UploadHandler;
 use App\Handler\VerifyHandler;
 use Asgrim\MiniMezzio\AppFactory;
+use Dotenv\Dotenv;
 use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
 use Laminas\ServiceManager\ServiceManager;
@@ -21,6 +22,17 @@ use Mezzio\Session\SessionMiddleware;
 use Mezzio\Twig\ConfigProvider as MezzioTwigConfigProvider;
 
 require __DIR__ . '/../vendor/autoload.php';
+
+$dotenv = Dotenv::createImmutable(__DIR__ . '/../');
+$dotenv->load();
+$dotenv->required([
+    'TWILIO_ACCOUNT_SID',
+    'TWILIO_AUTH_TOKEN',
+    'VERIFY_SERVICE_SID',
+    'UPLOAD_DIRECTORY',
+    'YOUR_PHONE_NUMBER',
+    'YOUR_USERNAME',
+]);
 
 $config                             = new ConfigAggregator([
     MezzioTwigConfigProvider::class,

--- a/public/index.php
+++ b/public/index.php
@@ -38,7 +38,7 @@ $dotenv->required([
     'YOUR_USERNAME',
 ]);
 
-$config                             = new ConfigAggregator([
+$config                                       = new ConfigAggregator([
     MezzioTwigConfigProvider::class,
     MezzioSessionConfigProvider::class,
     MezzioSessionExtConfigProvider::class,
@@ -59,18 +59,17 @@ $config                             = new ConfigAggregator([
         }
     },
 ])->getMergedConfig();
-$dependencies                       = $config['dependencies'];
-$dependencies['services']['config'] = $config;
+$dependencies                                 = $config['dependencies'];
+$dependencies['services']['config']           = $config;
 $dependencies['services']['config']['upload'] = [
     'upload_dir' => __DIR__ . '/../' . $_SERVER['UPLOAD_DIRECTORY'],
 ];
 $dependencies['services']['config']['users']  = [
     $_SERVER['YOUR_USERNAME'] => $_SERVER['YOUR_PHONE_NUMBER'],
 ];
-$container                          = new ServiceManager($dependencies);
+$container                                    = new ServiceManager($dependencies);
 $container->addAbstractFactory(new ReflectionBasedAbstractFactory());
-$container->setFactory(RouterInterface::class, static function () {
-    return new FastRouteRouter();
+$container->setFactory(RouterInterface::class, fn() => new FastRouteRouter());
 $container->setFactory(TwilioVerificationService::class, new class {
     public function __invoke(ContainerInterface $container): TwilioVerificationService
     {

--- a/public/index.php
+++ b/public/index.php
@@ -9,16 +9,24 @@ use Asgrim\MiniMezzio\AppFactory;
 use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
 use Laminas\ServiceManager\ServiceManager;
+use Mezzio\Flash\ConfigProvider as MezzioFlashConfigProvider;
+use Mezzio\Flash\FlashMessageMiddleware;
 use Mezzio\Router\FastRouteRouter;
 use Mezzio\Router\Middleware\DispatchMiddleware;
 use Mezzio\Router\Middleware\RouteMiddleware;
 use Mezzio\Router\RouterInterface;
+use Mezzio\Session\ConfigProvider as MezzioSessionConfigProvider;
+use Mezzio\Session\Ext\ConfigProvider as MezzioSessionExtConfigProvider;
+use Mezzio\Session\SessionMiddleware;
 use Mezzio\Twig\ConfigProvider as MezzioTwigConfigProvider;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $config                             = new ConfigAggregator([
     MezzioTwigConfigProvider::class,
+    MezzioSessionConfigProvider::class,
+    MezzioSessionExtConfigProvider::class,
+    MezzioFlashConfigProvider::class,
     new class ()
     {
         public function __invoke(): array
@@ -45,6 +53,8 @@ $container->setFactory(RouterInterface::class, static function () {
 
 $app = AppFactory::create($container, $container->get(RouterInterface::class));
 $app->pipe(RouteMiddleware::class);
+$app->pipe(SessionMiddleware::class);
+$app->pipe(FlashMessageMiddleware::class);
 $app->pipe(DispatchMiddleware::class);
 
 /**

--- a/src/App/Handler/FlashMessagesTrait.php
+++ b/src/App/Handler/FlashMessagesTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use Mezzio\Flash\FlashMessagesInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+trait FlashMessagesTrait
+{
+    public function setFlash(ServerRequestInterface $request, string $key, string $message): void
+    {
+        /** @var FlashMessagesInterface $flashMessage */
+        $flashMessage = $request->getAttribute('flash');
+        $flashMessage?->flash($key, $message);
+    }
+
+    public function getFlash(ServerRequestInterface $request, string $key): string|null
+    {
+        /** @var FlashMessagesInterface $flashMessage */
+        $flashMessage = $request->getAttribute('flash');
+        return $flashMessage?->getFlash($key) ?? null;
+    }
+}

--- a/src/App/Service/TwilioVerificationService.php
+++ b/src/App/Service/TwilioVerificationService.php
@@ -9,6 +9,8 @@ use Twilio\Rest\Verify\V2\Service\VerificationCheckInstance;
 use Twilio\Rest\Verify\V2\Service\VerificationInstance;
 use Twilio\Rest\Verify\V2\ServiceContext;
 
+use function strtolower;
+
 readonly class TwilioVerificationService
 {
     private ServiceContext $verifyService;
@@ -21,11 +23,11 @@ readonly class TwilioVerificationService
             ->services($this->serviceId);
     }
 
-    public function sendVerificationCode(string $recipient, string $channel = 'SMS'): VerificationInstance
+    public function sendVerificationCode(string $recipient, string $channel = 'sms'): VerificationInstance
     {
         return $this->verifyService
             ->verifications
-            ->create($recipient, $channel);
+            ->create($recipient, strtolower($channel));
     }
 
     public function validateVerificationCode(

--- a/templates/app/login.html.twig
+++ b/templates/app/login.html.twig
@@ -6,6 +6,12 @@
 
 {% block content %}
     <section class="text-slate-700/75">
+        {% if error is defined %}
+        <div class="mt-4 flex flex-row gap-x-2 items-center p-3 border-0 border-red-300 bg-red-100 rounded-md text-red-700">
+            <img src="/images/icons/cancel.png" alt="upload fail icon" width="32" height="32">
+            <p class="">{{ error }}</p>
+        </div>
+        {% endif %}
         <form class="mt-6 gap-y-4 max-w-3xl" method="post" enctype="application/x-www-form-urlencoded">
             <label class="mb-2 block font-medium " for="username">
                 Username:

--- a/templates/app/verify.html.twig
+++ b/templates/app/verify.html.twig
@@ -26,7 +26,7 @@
             <input type="hidden"
                    id="username"
                    name="username"
-                   value="msetter@twilio.com">
+                   value="{{ username }}">
         </form>
     </section>
 {% endblock %}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This change persists the username submitted in the login form so that it can be rendered in a hidden field in the verify form. Without this value, there is no way of knowing which user to validate the verification code for. So, this change has been made to rectify this situation, along with a host of covering tests to check the functionality.